### PR TITLE
fix: gpa positioning

### DIFF
--- a/style.css
+++ b/style.css
@@ -403,6 +403,7 @@ section .location {
 }
 
 .gpa {
+  clear: both;
   padding-bottom: 0.5em;
 }
 


### PR DESCRIPTION
Hello Francesco,

this PR proposes a fix for the GPA positioning in the education section.

this is the result **without** `clear: both`.

![image](https://user-images.githubusercontent.com/120051/60758777-76405700-a01b-11e9-906b-c5dab83446ba.png)

This instead **with** the clear.

![image](https://user-images.githubusercontent.com/120051/60758830-fc5c9d80-a01b-11e9-89e4-3d04d1dab43d.png)


What do you think of picking it in? 😃 


BTW thanks for the awesome theme! 🔥 
