### PR TITLE
Update font-awesome to v6.4.2

### DIFF
--- a/resume.hbs
+++ b/resume.hbs
@@ -4,8 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
   <title>{{#resume.basics}}{{name}}{{/resume.basics}}</title>
-  <link rel="stylesheet" href="https://use.fontawesome.com/releases/v5.15.4/css/all.css" integrity="sha384-DyZ88mC6Up2uqS4h/KRgHuoeGwBcD4Ng9SiP4dIRy0EXTlnuz47vAwmeGwVChigm" crossorigin="anonymous"/>
-  <style>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.4.2/css/all.min.css" integrity="sha512-z3gLpd7yknf1YoNbCzqRKc4qyor8gaKU1qmn+CShxbuBusANI9QpRohGBreCFkKxLhei6S9CQXFEbbKuqLg0DA==" crossorigin="anonymous" referrerpolicy="no-referrer" />  <style>
   {{{css}}}
   </style>
   

--- a/style.css
+++ b/style.css
@@ -751,7 +751,7 @@ section .location {
     display: block;
     opacity: 1 !important;
   }
-  .fa-map-marker-alt:before {
+  .fa-location-dot:before {
     padding-left: 0.1em;
   }
 }

--- a/theme/partials/basics.hbs
+++ b/theme/partials/basics.hbs
@@ -39,19 +39,19 @@
 		<div id="contact">
 			{{#if website}}
 			<div class="website">
-				<span class="fas fa-external-link-alt"></span>
+				<span class="fa-solid fa-up-right-from-square"></span>
 				<a class="hide-href-print" target="_blank" target="_blank" href="{{website}}">{{website}}</a>
 			</div>
 			{{/if}}
 			{{#if email}}
 			<div class="email">
-				<span class="far fa-envelope"></span>
+				<span class="fa-regular fa-envelope"></span>
 				<a class="hide-href-print" href="mailto:{{email}}">{{email}}</a>
 			</div>
 			{{/if}}
 			{{#if phone}}
 			<div class="phone">
-				<span class="fas fa-mobile-alt"></span>
+				<span class="fa-solid fa-mobile-screen-button"></span>
 				<a class="hide-href-print" href="tel:{{phone}}">{{phone}}</a>
 			</div>
 			{{/if}}
@@ -63,7 +63,7 @@
 			<div class="item">
 				{{#if network}}
 				<div class="username">
-					<span class="fab fa-{{spaceToDash network}} {{spaceToDash network}} social"></span>
+					<span class="fa-brands fa-{{spaceToDash network}} {{spaceToDash network}} social"></span>
 					{{#if url}}
 					<span class="url">
 						<a target="_blank" href="{{url}}">{{username}}</a>

--- a/theme/partials/certificates.hbs
+++ b/theme/partials/certificates.hbs
@@ -29,7 +29,7 @@
           <div class="item">
             {{#if url}}
               <span class="url">
-                <span class="fas fa-external-link-alt"></span>
+                <span class="fa-solid fa-up-right-from-square"></span>
                 <a target="_blank" href="{{url}}">{{url}}</a>
               </span>
             {{/if}}

--- a/theme/partials/education.hbs
+++ b/theme/partials/education.hbs
@@ -48,7 +48,7 @@
 
       {{#location}}
       <span class="location">
-        <span class="fas fa-map-marker-alt"></span>
+        <span class="fa-solid fa-location-dot"></span>
         {{#if city}}
         <span class="city">{{city}}</span>
         {{/if}}

--- a/theme/partials/projects.hbs
+++ b/theme/partials/projects.hbs
@@ -29,7 +29,7 @@
       {{/if}}
       {{#location}}
       <span class="location">
-      <span class="fas fa-map-marker-alt"></span>
+      <span class="fa-solid fa-location-dot"></span>
       {{#if city}}
       <span class="city">{{city}},</span>
       {{/if}}
@@ -45,7 +45,7 @@
       {{/location}}
       {{#if url}}
       <span class="website">
-        <span class="fas fa-external-link-alt"></span>
+        <span class="fa-solid fa-up-right-from-square"></span>
         <a target="_blank" href="{{url}}">{{url}}</a>
       </span>
       {{/if}}

--- a/theme/partials/publications.hbs
+++ b/theme/partials/publications.hbs
@@ -21,7 +21,7 @@
           <span class="name">
             {{#if website}}
             <span class="website">
-              <span class="fas fa-external-link-alt"></span>
+              <span class="fa-solid fa-up-right-from-square"></span>
               <a target="_blank" href="{{website}}">{{name}}</a>
             </span>
             {{else}}

--- a/theme/partials/volunteer.hbs
+++ b/theme/partials/volunteer.hbs
@@ -44,13 +44,13 @@
       {{/if}}
       {{#if website}}
       <div class="website">
-        <span class="fas fa-external-link-alt"></span>
+        <span class="fa-solid fa-up-right-from-square"></span>
         <a target="_blank" href="{{website}}">{{website}}</a>
       </div>
       {{/if}}
       {{#location}}
       <span class="location">
-        <span class="fas fa-map-marker-alt"></span>
+        <span class="fa-solid fa-location-dot"></span>
         {{#if city}}
         <span class="city">
           {{city}},

--- a/theme/partials/work.hbs
+++ b/theme/partials/work.hbs
@@ -36,7 +36,7 @@
 
       {{#location}}
       <span class="location">
-        <span class="fas fa-map-marker-alt"></span>
+        <span class="fa-solid fa-location-dot"></span>
         {{#if city}}
         <span class="city">{{city}}</span>
         {{/if}}
@@ -47,7 +47,7 @@
       {{/location}}
       {{#if url}}
       <span class="url">
-        <span class="fas fa-external-link-alt"></span>
+        <span class="fa-solid fa-up-right-from-square"></span>
         <a target="_blank" href="{{url}}">{{url}}</a>
       </span> {{/if}} {{#if keywords.length}}
       <ul class="keywords">


### PR DESCRIPTION
This pull requests updates font-awesome to the new major version v6. Therefore some minor changes needed to be made.

- From v6, there is no official cdn anymore. font-awesome recommends using kits or self-host the packages. I decided to use the [cdnjs cdn](https://cdnjs.com/libraries/font-awesome)
- Some icons got renamed, see [here](https://fontawesome.com/docs/web/setup/upgrade/whats-changed#icons-renamed-in-version-6)
    - fa-map-marker-alt -> fa-location-dot
    - fa-external-link-alt -> fa-up-right-from-square
    - fa-mobile-alt -> fa-mobile-screen-button
- Also the category names changed, see [here](https://fontawesome.com/docs/web/setup/upgrade/whats-changed#full-style-names)
    - fas -> fa-solid
    - fab -> fa-brands
    - far -> fa-regular