### PR TITLE
Fix project description

### DIFF
--- a/theme/partials/projects.hbs
+++ b/theme/partials/projects.hbs
@@ -47,8 +47,8 @@
       </ul>
       {{/if}}
       <div class="item">
-        {{#if summary}}
-          <div class="summary">{{paragraphSplit summary}}</div>
+        {{#if description}}
+          <div class="summary">{{paragraphSplit description}}</div>
         {{/if}}
         {{#if highlights.length}}
         <ul class="highlights">


### PR DESCRIPTION
According to the JSON Resume schema, project elements have a property named description, unlike work elements, which have a property named summary. 
This pull request corrects the project partial to ensure it works with the specified description property.